### PR TITLE
Move generateId to try-catch block

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -291,11 +291,18 @@ Server.prototype.generateId = function (req) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
+  var id;
+
+  try {
+    id = this.generateId(req);
+  } catch (e) {
+    sendErrorMessage(req, req.res, e.message || Server.errors.BAD_REQUEST);
+    return;
+  }
+
   debug('handshaking client "%s"', id);
 
   try {
-    var id = this.generateId(req);
-
     var transport = new transports[transportName](req);
     if ('polling' === transportName) {
       transport.maxHttpBufferSize = this.maxHttpBufferSize;
@@ -310,7 +317,7 @@ Server.prototype.handshake = function (transportName, req) {
       transport.supportsBinary = true;
     }
   } catch (e) {
-    sendErrorMessage(req, req.res, e.message || Server.errors.BAD_REQUEST);
+    sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
     return;
   }
   var socket = new Socket(id, this, transport, req);

--- a/lib/server.js
+++ b/lib/server.js
@@ -295,7 +295,7 @@ Server.prototype.handshake = function (transportName, req) {
 
   try {
     var id = this.generateId(req);
-    
+
     var transport = new transports[transportName](req);
     if ('polling' === transportName) {
       transport.maxHttpBufferSize = this.maxHttpBufferSize;

--- a/lib/server.js
+++ b/lib/server.js
@@ -291,11 +291,11 @@ Server.prototype.generateId = function (req) {
  */
 
 Server.prototype.handshake = function (transportName, req) {
-  var id = this.generateId(req);
-
   debug('handshaking client "%s"', id);
 
   try {
+    var id = this.generateId(req);
+    
     var transport = new transports[transportName](req);
     if ('polling' === transportName) {
       transport.maxHttpBufferSize = this.maxHttpBufferSize;
@@ -310,7 +310,7 @@ Server.prototype.handshake = function (transportName, req) {
       transport.supportsBinary = true;
     }
   } catch (e) {
-    sendErrorMessage(req, req.res, Server.errors.BAD_REQUEST);
+    sendErrorMessage(req, req.res, e.message || Server.errors.BAD_REQUEST);
     return;
   }
   var socket = new Socket(id, this, transport, req);


### PR DESCRIPTION
### The kind of change this PR does introduce

* [x] a bug fix
* [ ] a new feature
* [ ] an update to the documentation
* [ ] a code change that improves performance
* [ ] other

### Current behaviour
Impossible to handle an error thrown within extended `generateId` function

### New behaviour
Handling an error throw within extended `generateId` function

### Other information (e.g. related issues)


